### PR TITLE
chore: update domain from allons-y.llc to allons-y.studio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,5 +18,3 @@
 ### Features
 
 - initialize glob concatenation project ([cacd612](https://github.com/castastrophe/glob-concat-cli/commit/cacd612ab660707429c9d87df9a66972df5b185e))
-
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,4 @@
 ### Features
 
 - initialize glob concatenation project ([cacd612](https://github.com/castastrophe/glob-concat-cli/commit/cacd612ab660707429c9d87df9a66972df5b185e))
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,4 @@
 
 - initialize glob concatenation project ([cacd612](https://github.com/castastrophe/glob-concat-cli/commit/cacd612ab660707429c9d87df9a66972df5b185e))
 
+

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "author": "Cassondra Roberts <castastrophe@users.noreply.github.com> (https://allons-y.studio)",
   "repository": {
     "type": "git",
-    "url": "https://github.com/castastrophe/glob-concat-cli.git"
+    "url": "https://github.com/allonsy-studio/glob-concat-cli.git"
   },
   "bugs": {
-    "url": "https://github.com/castastrophe/glob-concat-cli/issues"
+    "url": "https://github.com/allonsy-studio/glob-concat-cli/issues"
   },
   "type": "module",
   "module": "index.js",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "description": "A concatenation tool leveraging fast-glob for CLIs",
   "license": "Apache-2.0",
-  "author": "Cassondra Roberts <castastrophe@users.noreply.github.com> (https://allons-y.llc)",
+  "author": "Cassondra Roberts <castastrophe@users.noreply.github.com> (https://allons-y.studio)",
   "repository": {
     "type": "git",
     "url": "https://github.com/castastrophe/glob-concat-cli.git"


### PR DESCRIPTION
## What
Update domain references from `allons-y.llc` to `allons-y.studio`.

## Why
Studio rebrand — the `.llc` domain is being retired in favour of `.studio`.

## How
Find-and-replace author URL in `package.json`.

## Test plan
Verified no remaining `allons-y.llc` references in source files (excluding `.git` and `node_modules`).

## Checklist
- [x] My code follows the project's style and conventions.
- [x] I have performed a self-review of my changes.
- [ ] I have added or updated tests where appropriate.
- [x] I have updated documentation where appropriate.
- [x] My changes generate no new warnings or accessibility regressions.
- [x] I have read the [Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](CODE_OF_CONDUCT.md).
