### PR TITLE
fix: update repository URL to org after transfer

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "author": "Cassondra Roberts <castastrophe@users.noreply.github.com> (https://allons-y.studio)",
   "repository": {
     "type": "git",
-    "url": "https://github.com/castastrophe/glob-concat-cli.git"
+    "url": "https://github.com/allonsy-studio/glob-concat-cli.git"
   },
   "bugs": {
-    "url": "https://github.com/castastrophe/glob-concat-cli/issues"
+    "url": "https://github.com/allonsy-studio/glob-concat-cli/issues"
   },
   "type": "module",
   "module": "index.js",


### PR DESCRIPTION
## Why

The release workflow fails because semantic-release pushes to `castastrophe/glob-concat-cli.git` instead of `allonsy-studio/glob-concat-cli.git`.

semantic-release derives its push target from `package.json`'s `repository.url` field whenever `.releaserc` provides no explicit `repositoryUrl` (this repo's `.releaserc` has none). The local `git remote` correctly points at `allonsy-studio`, but the release plugins (`@semantic-release/git`, `@semantic-release/github`) override it with the stale `package.json` value. GitHub's post-transfer redirects mask the problem for normal shell `git` use, so it only surfaces when an automated tool computes the canonical URL.

## Changes

- `repository.url` → `allonsy-studio/glob-concat-cli.git` (fixes the failure)
- `bugs.url` → `allonsy-studio/glob-concat-cli/issues` (stale from the same transfer)

`author` and `funding` links intentionally keep `castastrophe` — those are personal username / sponsorship links, not the repo location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)